### PR TITLE
feat(env::var): add remove_var function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,17 @@ assert!(!current_dir.ends_with("src"));
 assert!(std::env::var("TEST_TMP_ENV").is_err());
 ```
 
-- To temporary create a directory
+- To temporary remove an environment variable:
+
+```rust
+{
+    let _tmp_env = tmp_env::remove_var("TEST_TMP_ENV");
+    assert!(std::env::var("TEST_TMP_ENV").is_err());
+}
+// The environment variable is now restored
+```
+
+- To temporary create a directory:
 
 ```rust
 {


### PR DESCRIPTION
I do not know if you still check this repository, but as it was corresponding to my needs with only a missing function, I wanted to add the function.

I know there is the alternative of `temp-env`, but I prefer this minimalistic style rather than the bulky style of `temp-env`.